### PR TITLE
Made changes in get_config, load_merge/replace and close method

### DIFF
--- a/napalm_sros/sros.py
+++ b/napalm_sros/sros.py
@@ -105,6 +105,7 @@ class NokiaSROSDriver(NetworkDriver):
     def close(self):
         """Implement the NAPALM method close (mandatory)"""
         # Close the NETCONF connection with the host
+
         self.conn_ssh.close()
         self.conn.close_session()
 
@@ -327,16 +328,16 @@ class NokiaSROSDriver(NetworkDriver):
                 self.conn.validate(source="candidate")
 
             else:
-                configuration = configuration.split(" \n ")
+                configuration = configuration.split("\n")
                 configuration.insert(0, "edit-config exclusive")
                 buff = self._perform_cli_commands(configuration)
                 if buff is not None:
                     for item in buff.split("\n"):
                         if "MINOR: " in item:
-                            raise MergeConfigException()
+                            raise MergeConfigException("Merger issue : %s", item)
 
         except MergeConfigException as me:
-            raise MergeConfigException(me)
+            raise MergeConfigException("Merger issue : %s", me)
 
     def load_replace_candidate(self, filename=None, config=None):
         """
@@ -374,9 +375,9 @@ class NokiaSROSDriver(NetworkDriver):
                 if buff is not None:
                     for item in buff.split("\n"):
                         if "MINOR" in item:
-                            raise ReplaceConfigException()
+                            raise ReplaceConfigException("Replace issue: %s", item)
         except ReplaceConfigException as rex:
-            raise ReplaceConfigException(rex)
+            raise ReplaceConfigException("Replace issue: %s", rex)
 
     def get_facts(self):
         """
@@ -951,8 +952,6 @@ class NokiaSROSDriver(NetworkDriver):
                     continue
                 if "[]" in item:
                     continue
-                elif "configure" in item:
-                    new_buff += "configure{" + "\n"
                 elif cmd_line_pattern.search(item) or not row:
                     continue
                 elif "persistent-indices" in item:


### PR DESCRIPTION
1. Persistent indices should not be included while returning config in get_config
2. When candidate config is return it does have first line as configure in it
3. When we run get_config() twice and get running config, the command is not showed in second time as it appeared before
4. in close method added line to close paramiko ssh connection to the router
5. load merge prints exception and can take input in MD-CLI, CLI, XML format
6. load replace prints exception


