### PR TITLE
R23 fixes

### DIFF
--- a/napalm_sros/api/get_bgp_neighbors.py
+++ b/napalm_sros/api/get_bgp_neighbors.py
@@ -70,7 +70,7 @@ NEIGHBOR_STATS = """
 """
 
 GET_BGP_NEIGHBORS = """
-    <filter>
+    <filter xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
         <configure xmlns="urn:nokia.com:sros:ns:yang:sr:conf">
             <router>
             <router-name/>

--- a/napalm_sros/api/get_bgp_neighbors_detail.py
+++ b/napalm_sros/api/get_bgp_neighbors_detail.py
@@ -104,7 +104,7 @@ NEIGHBOR_STATS = """
 """
 
 GET_BGP_NEIGHBORS_DETAILS = """
-    <filter>
+    <filter xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
         <configure xmlns="urn:nokia.com:sros:ns:yang:sr:conf">
             <router>
                 <router-name/>

--- a/napalm_sros/nc_filters.py
+++ b/napalm_sros/nc_filters.py
@@ -34,8 +34,8 @@ GET_FACTS = {
 }
 
 
-GET_INTERFACES = {
-    "_": """
+def GET_INTERFACES(R19):
+  return f"""
     <filter xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
         <state xmlns="urn:nokia.com:sros:ns:yang:sr:state">
             <port>
@@ -49,7 +49,7 @@ GET_INTERFACES = {
             <router>
                 <interface>
                     <oper-ip-mtu />
-                    <if-oper-status />
+                    { '<if-oper-status/>' if R19 else '<oper-state/>' }
                     <last-oper-change/>
                 </interface>
             </router>
@@ -80,7 +80,6 @@ GET_INTERFACES = {
         </configure>
     </filter>
     """
-}
 
 GET_INTERFACES_COUNTERS = {
     "_": """

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -49,6 +49,7 @@ class PatchedNokiaSROSDriver(sros.NokiaSROSDriver):
         self.ssh_channel = FakeSSHConnectionChannel()
         self.conn_ssh = FakeSSHConnection()
         self.manager = FakeManager()
+        self.R19 = False
 
     def is_alive(self):
         return {"is_alive": True}

--- a/test/unit/mocked_data/test_get_interfaces/normal/get_interfaces.xml
+++ b/test/unit/mocked_data/test_get_interfaces/normal/get_interfaces.xml
@@ -37,7 +37,7 @@
             <interface>
                 <interface-name>system</interface-name>
                 <oper-ip-mtu>1500</oper-ip-mtu>
-                <if-oper-status>up</if-oper-status>
+                <oper-state>up</oper-state>
                 <last-oper-change>2020-04-13T15:53:27.0Z</last-oper-change>
             </interface>
         </router>


### PR DESCRIPTION
* Set XML namespace for get_bgp_neighbors_* too

* Check SR OS version and adjust state XML filter accordingly (R19 uses if-oper-status, after it became oper-state)